### PR TITLE
Verberg thema-toggle en lege hamburger op landingspagina's

### DIFF
--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -29,6 +29,7 @@ export interface Props {
   isDark?: boolean;
   isFullWidth?: boolean;
   showToggleTheme?: boolean;
+  showToggleMenu?: boolean;
   showRssFeed?: boolean;
   showLanguageSwitcher?: boolean;
   position?: string;
@@ -42,6 +43,7 @@ const {
   isDark = false,
   isFullWidth = false,
   showToggleTheme = false,
+  showToggleMenu = true,
   showRssFeed = false,
   showLanguageSwitcher = false,
   position = 'center',
@@ -82,9 +84,13 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
       <a class="flex items-center" href={getHomePermalink()}>
         <Logo />
       </a>
-      <div class="flex items-center md:hidden">
-        <ToggleMenu />
-      </div>
+      {
+        showToggleMenu && (
+          <div class="flex items-center md:hidden">
+            <ToggleMenu />
+          </div>
+        )
+      }
     </div>
     <nav
       class="items-center w-full md:w-auto hidden md:flex md:mx-5 text-default overflow-y-auto overflow-x-hidden md:overflow-y-visible md:overflow-x-auto md:justify-self-center"

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -14,7 +14,7 @@ const { metadata } = Astro.props;
 <PageLayout metadata={metadata}>
   <Fragment slot="header">
     <slot name="header">
-      <Header showToggleTheme />
+      <Header showToggleMenu={false} />
     </slot>
   </Fragment>
   <slot />


### PR DESCRIPTION
## Wat

Op de landingspagina's:
- thema-toggle weggehaald (`showToggleTheme` niet meer meegegeven aan `Header`)
- hamburger-menu verborgen op kleine schermen — die opende een lege nav

## Hoe

- Nieuwe `showToggleMenu` prop op `Header` (default `true`, dus gewone pagina's blijven gelijk)
- `LandingLayout` geeft nu `showToggleMenu={false}` mee en laat `showToggleTheme` weg

🤖 Generated with [Claude Code](https://claude.com/claude-code)